### PR TITLE
Fix LDAP search for invalid dn.

### DIFF
--- a/public/main.php
+++ b/public/main.php
@@ -158,7 +158,7 @@ elseif($login->login_check())
 	$domain = $_SESSION["phamm"]["domain"];
     
     // Create domain object
-    if (isset($domain))
+    if (isset($domain) && !empty($domain))
     {
 	$domain_obj = new PhammLdap();
 	$domain_val = $domain_obj->phamm_self_values ('vd='.$domain.','.LDAP_BASE, $filter="(vd=$domain)");


### PR DESCRIPTION
When logging in as administrator, phamm sends two broken LDAP requests that result in LDAP (slapd) log messages of the form:
`do_search: invalid dn: "vd=,ou=domains,dc=example,dc=org"`

The reason is, that `isset($domain)` in public/main.php line 161 always returns true, because a few lines before, phamm_set_var assigns some value to $domain (even though this can be null).

This pull request fixes the problem by additionally making sure that $domain is not empty.
