### PR TITLE
Add missing break statement in 'crypt' case

### DIFF
--- a/controllers/helpers.php
+++ b/controllers/helpers.php
@@ -196,6 +196,7 @@ function phamm_password_hash($password_clear)
         default:
             $password_hash = '{CRYPT}'.crypt($password_clear, $salt);
         }
+        break;
         
 
     case 'md5':


### PR DESCRIPTION
Ensures that hashes use CRYPT, when selected, and not MD5
